### PR TITLE
Added scenes, updated output preview, fixed action(s)/params

### DIFF
--- a/src/assets/example.json
+++ b/src/assets/example.json
@@ -206,6 +206,29 @@
         "voice_lift.main_method=voice_lift",
         "voice_lift.icon=mdi:mic"
     ],
+    "scenes": [
+        {
+            "id": "scene_presentation",
+            "name": "Presentation Mode",
+            "icon": "icon_projector",
+            "commands": [
+                "cc_light.power.off",
+                "cc_projector.power.on",
+                "generic_curtain.power.off"
+            ]
+        },
+        {
+            "id": "scene_meeting",
+            "name": "Meeting Mode",
+            "icon": "mdi:groups",
+            "commands": [
+                "cc_light.power.on",
+                "cc_projector.power.off",
+                "generic_curtain.power.on",
+                "voice_lift.voice_lift.on"
+            ]
+        }
+    ],
     "rules": {
         "meeting_started": [
             "cc_light.power.on",

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -104,7 +104,7 @@
                                         </div>
                                     </div>
                                 </template>
-                                <template v-else>
+                                <template v-else-if="port.main_method.type != 'actions'">
                                     <button
                                         class="btn-zoom"
                                         :class="{
@@ -169,7 +169,7 @@
                                             </button>
                                         </div>
                                     </div>
-                                    <div v-else>
+                                    <div v-else-if="method.type != 'actions'">
                                         <button
                                             class="btn-zoom"
                                             :class="{
@@ -325,6 +325,21 @@ export default {
                             json.styles.push(port.id + '.main_method=power');
                         });
                     });
+
+                // Zoom rejects the entire profile if a method has type 'action' but also has a params
+                // array. The 'action' type is for parameterless commands; use 'actions' (plural) when
+                // params are present. Tested on Zoom Room version 6.6.1 (8162).
+                json.adapters.forEach((adapter) => {
+                    adapter.ports.forEach((port) => {
+                        port.methods.forEach((method) => {
+                            if (method.type == 'action' && method.params) {
+                                throw new Error(
+                                    `Method '${port.id}.${method.id}' has type 'action' but includes params. Use type 'actions' when params are present.`
+                                );
+                            }
+                        });
+                    });
+                });
 
                 // Take the information in the styles array and use it to populate the adapters array with
                 // information to better style things inline.  This makes for a clunkier object but does all

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -29,6 +29,37 @@
             <div
                 id="zoom-controls"
                 v-if="calculatedControls != null">
+                <div
+                    class="scenes-section"
+                    v-if="calculatedControls.scenes && calculatedControls.scenes.length > 0">
+                    <div class="section-header">
+                        <p class="section-label">Scenes</p>
+                        <button
+                            v-if="calculatedControls.scenes.length > 8"
+                            class="btn-collapse"
+                            :class="{ expanded: scenesExpanded }"
+                            @click="scenesExpanded = !scenesExpanded">
+                            <span class="material-icons">keyboard_arrow_down</span>
+                        </button>
+                    </div>
+                    <div class="scenes-grid">
+                        <button
+                            v-for="scene in visibleScenes"
+                            class="btn-scene"
+                            @click="sceneClick(scene)">
+                            <span
+                                v-if="scene.icon && scene.icon.startsWith('mdi:')"
+                                :class="getMaterialIconClass(scene.icon)"
+                                >{{ getMaterialIconName(scene.icon) }}</span
+                            >
+                            <img
+                                v-else-if="scene.icon"
+                                :src="getIconUrl(scene.icon)" />
+                            <p>{{ scene.name || scene.id }}</p>
+                        </button>
+                    </div>
+                </div>
+                <p class="section-label">Devices</p>
                 <template v-for="adapter in calculatedControls.adapters">
                     <div
                         v-for="port in adapter.ports"
@@ -185,6 +216,7 @@ export default {
         errorMessage: '',
         target: '',
         command: '',
+        scenesExpanded: false,
     }),
     methods: {
         getIconUrl(iconName) {
@@ -231,22 +263,34 @@ export default {
             }
         }
         },
+        formatCommand(adapter, port, method, param) {
+            if (adapter.model == 'iTachIP2CC') {
+                return `Relay ${param.position} ${param.name}`;
+            }
+            let command = method.command;
+            if (method.type == 'actions' && param) {
+                command = command.replace('%', param.value);
+            }
+            return command;
+        },
         zoomClick(adapter, port, method, param) {
             this.target = port.id;
-
-            if (adapter.model == 'iTachIP2CC') {
-                this.command = `Relay ${param.position} ${param.name}`;
-            } else {
-                this.command = method.command;
-                if (method.type == 'actions') {
-                    this.command = this.command.replace('%', param.value);
-                }
-            }
+            this.command = this.formatCommand(adapter, port, method, param);
+        },
+        sceneClick(scene) {
+            this.target = scene.id;
+            this.command = scene.resolvedCommands.join('\n');
         },
     },
     computed: {
         exampleJson() {
             return exampleJson;
+        },
+        visibleScenes() {
+            if (!this.calculatedControls || !this.calculatedControls.scenes) return [];
+            const scenes = this.calculatedControls.scenes;
+            if (this.scenesExpanded || scenes.length <= 8) return scenes;
+            return scenes.slice(0, 8);
         },
         calculatedControls() {
             try {
@@ -387,6 +431,71 @@ export default {
                     });
                 });
 
+                // Process scenes: validate structure and pre-resolve each command string
+                // (e.g. "light1.power.on") into the actual formatted command that would be sent.
+                if (json.scenes) {
+                    if (json.scenes.length > 20) {
+                        throw new Error("Scenes array can contain at most 20 scenes");
+                    }
+
+                    json.scenes.forEach((scene) => {
+                        if (!scene.id) {
+                            throw new Error("Scene is missing required 'id' field");
+                        }
+                        if (!Array.isArray(scene.commands)) {
+                            throw new Error(`Scene '${scene.id}' is missing required 'commands' array`);
+                        }
+                        // Zoom's docs state: "Today, a maximum of 20 scenes can be configured.
+                        // Within those scenes, a maximum of 50 independent commands are supported."
+                        // The 20-scene cap is enforced, but an actual Zoom Room running version
+                        // 6.6.1 (8162) accepted a scene with 52 commands and executed all of them.
+                        // Leaving this check disabled until the cap is observed in practice.
+                        // if (scene.commands.length > 50) {
+                        //     throw new Error(`Scene '${scene.id}' has more than 50 commands (max 50)`);
+                        // }
+
+                        scene.resolvedCommands = scene.commands.map((commandRef) => {
+                            let [portId, methodId, paramId] = commandRef.split('.');
+
+                            let adapter, port;
+                            json.adapters.find((a) => {
+                                let foundPort = a.ports.find((p) => p.id == portId);
+                                if (foundPort) {
+                                    adapter = a;
+                                    port = foundPort;
+                                    return true;
+                                }
+                                return false;
+                            });
+
+                            if (!port) {
+                                throw new Error(
+                                    `Scene '${scene.id}' references unknown port '${portId}' in command '${commandRef}'`
+                                );
+                            }
+
+                            let method = port.methods.find((m) => m.id == methodId);
+                            if (!method) {
+                                throw new Error(
+                                    `Scene '${scene.id}' references unknown method '${methodId}' on port '${portId}' in command '${commandRef}'`
+                                );
+                            }
+
+                            let param;
+                            if (paramId) {
+                                param = method.params && method.params.find((p) => p.id == paramId);
+                                if (!param) {
+                                    throw new Error(
+                                        `Scene '${scene.id}' references unknown param '${paramId}' on method '${portId}.${methodId}' in command '${commandRef}'`
+                                    );
+                                }
+                            }
+
+                            return this.formatCommand(adapter, port, method, param);
+                        });
+                    });
+                }
+
                 // Zoom has a bug where an empty rule needs to be fully empty or the json fails to load, even if it is proper json.
                 // "meeting_started": [] works
                 // "meeting_started": [ ] will fail
@@ -461,6 +570,9 @@ $zoom-button-height: 58px;
                 text-align: left;
                 width: 100%;
                 font-size: 1rem;
+                white-space: pre-line;
+                max-height: 200px;
+                overflow-y: auto;
             }
         }
     }
@@ -486,10 +598,92 @@ $zoom-button-height: 58px;
         #zoom-controls {
             display: flex;
             flex-direction: column;
-            align-items: center;
+            align-items: stretch;
             justify-content: flex-start;
             gap: 1rem;
             width: $zoom-panel-width;
+
+            .section-label {
+                font-size: 16px;
+                font-weight: 500;
+                color: $color-text-dark;
+                opacity: 0.7;
+                margin-left: 4px;
+            }
+
+            .scenes-section {
+                display: flex;
+                flex-direction: column;
+                gap: 0.75rem;
+
+                .section-header {
+                    display: flex;
+                    flex-direction: row;
+                    align-items: center;
+                    justify-content: space-between;
+                    padding-right: 4px;
+                }
+
+                .btn-collapse {
+                    @extend %btn-shared;
+
+                    border: 1px solid $color-border;
+                    border-radius: 50%;
+                    background: transparent;
+                    color: $color-text-dark;
+                    width: 28px;
+                    height: 28px;
+                    padding: 0;
+                    line-height: 1;
+
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+
+                    .material-icons {
+                        font-size: 20px;
+                        transition: transform 0.15s ease-in-out;
+                    }
+
+                    &.expanded .material-icons {
+                        transform: rotate(180deg);
+                    }
+                }
+
+                .scenes-grid {
+                    display: grid;
+                    grid-template-columns: 1fr 1fr;
+                    gap: 1rem;
+                }
+
+                .btn-scene {
+                    @extend %btn-shared;
+
+                    border: none;
+                    border-radius: 10px;
+                    background: $color-zoom-port-background;
+                    color: $color-text-dark;
+                    font-size: 19px;
+                    font-weight: bold;
+                    padding: 22px 30px;
+                    min-height: $zoom-button-height;
+                    text-align: left;
+
+                    display: flex;
+                    flex-direction: row;
+                    align-items: center;
+                    gap: 1rem;
+
+                    p {
+                        white-space: normal;
+                        overflow-wrap: anywhere;
+                    }
+
+                    &:active {
+                        background: darken($color-zoom-port-background, 5);
+                    }
+                }
+            }
 
             .port {
                 border-radius: 10px;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -9,13 +9,13 @@
             <div
                 id="zoom-output"
                 v-if="target">
-                <p class="zoom-output-label">Target:</p>
+                <p class="zoom-output-label">Event:</p>
                 <p
                     class="zoom-output-content"
                     id="zoom-output-target">
                     {{ target }}
                 </p>
-                <p class="zoom-output-label">Command:</p>
+                <p class="zoom-output-label">Command(s):</p>
                 <p
                     class="zoom-output-content"
                     id="zoom-output-command">
@@ -265,16 +265,16 @@ export default {
         },
         formatCommand(adapter, port, method, param) {
             if (adapter.model == 'iTachIP2CC') {
-                return `Relay ${param.position} ${param.name}`;
+                return `${adapter.ip}: Relay ${param.position} ${param.name}`;
             }
             let command = method.command;
             if (method.type == 'actions' && param) {
                 command = command.replace('%', param.value);
             }
-            return command;
+            return `${adapter.ip}: ${command}`;
         },
         zoomClick(adapter, port, method, param) {
-            this.target = port.id;
+            this.target = param ? `${port.id}.${method.id}.${param.id}` : `${port.id}.${method.id}`;
             this.command = this.formatCommand(adapter, port, method, param);
         },
         sceneClick(scene) {

--- a/test profiles/21 scenes.json
+++ b/test profiles/21 scenes.json
@@ -1,0 +1,293 @@
+{
+    "adapters": [
+        {
+            "model": "GenericNetworkAdapter",
+            "ip": "tcp://192.168.49.16:5000",
+            "ports": [
+                {
+                    "id": "display",
+                    "name": "Display",
+                    "methods": [
+                        {
+                            "id": "power",
+                            "name": "Power",
+                            "command": "POWR%   \\x0D",
+                            "params": [
+                                {
+                                    "id": "on",
+                                    "name": "On",
+                                    "value": "1"
+                                },
+                                {
+                                    "id": "off",
+                                    "name": "Off",
+                                    "value": "0"
+                                }
+                            ],
+                            "type": "actions"
+                        },
+                        {
+                            "id": "source",
+                            "name": "Source",
+                            "command": "IAVD%   \\x0D",
+                            "params": [
+                                {
+                                    "id": "1",
+                                    "name": "Input 1",
+                                    "value": "1"
+                                },
+                                {
+                                    "id": "2",
+                                    "name": "Input 2",
+                                    "value": "2"
+                                },
+                                {
+                                    "id": "3",
+                                    "name": "Input 3",
+                                    "value": "3"
+                                },
+                                {
+                                    "id": "4",
+                                    "name": "Input 4",
+                                    "value": "4"
+                                },
+                                {
+                                    "id": "5",
+                                    "name": "Input 5",
+                                    "value": "5"
+                                },
+                                {
+                                    "id": "6",
+                                    "name": "Input 6",
+                                    "value": "6"
+                                },
+                                {
+                                    "id": "7",
+                                    "name": "Input 7",
+                                    "value": "7"
+                                },
+                                {
+                                    "id": "8",
+                                    "name": "Input 8",
+                                    "value": "8"
+                                },
+                                {
+                                    "id": "9",
+                                    "name": "Input 9",
+                                    "value": "9"
+                                },
+                                {
+                                    "id": "10",
+                                    "name": "Input 10",
+                                    "value": "10"
+                                },
+                                {
+                                    "id": "11",
+                                    "name": "Input 11",
+                                    "value": "11"
+                                },
+                                {
+                                    "id": "12",
+                                    "name": "Input 12",
+                                    "value": "12"
+                                },
+                                {
+                                    "id": "13",
+                                    "name": "Input 13",
+                                    "value": "13"
+                                },
+                                {
+                                    "id": "14",
+                                    "name": "Input 14",
+                                    "value": "14"
+                                },
+                                {
+                                    "id": "15",
+                                    "name": "Input 15",
+                                    "value": "15"
+                                },
+                                {
+                                    "id": "16",
+                                    "name": "Input 16",
+                                    "value": "16"
+                                },
+                                {
+                                    "id": "17",
+                                    "name": "Input 17",
+                                    "value": "17"
+                                },
+                                {
+                                    "id": "18",
+                                    "name": "Input 18",
+                                    "value": "18"
+                                },
+                                {
+                                    "id": "19",
+                                    "name": "Input 19",
+                                    "value": "19"
+                                }
+                            ],
+                            "type": "actions"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "scenes": [
+        {
+            "id": "scene_01",
+            "name": "Power On",
+            "icon": "icon_power",
+            "commands": [
+                "display.power.on"
+            ]
+        },
+        {
+            "id": "scene_02",
+            "name": "Power Off",
+            "icon": "icon_power",
+            "commands": [
+                "display.power.off"
+            ]
+        },
+        {
+            "id": "scene_03",
+            "name": "Input 1",
+            "commands": [
+                "display.source.1"
+            ]
+        },
+        {
+            "id": "scene_04",
+            "name": "Input 2",
+            "commands": [
+                "display.source.2"
+            ]
+        },
+        {
+            "id": "scene_05",
+            "name": "Input 3",
+            "commands": [
+                "display.source.3"
+            ]
+        },
+        {
+            "id": "scene_06",
+            "name": "Input 4",
+            "commands": [
+                "display.source.4"
+            ]
+        },
+        {
+            "id": "scene_07",
+            "name": "Input 5",
+            "commands": [
+                "display.source.5"
+            ]
+        },
+        {
+            "id": "scene_08",
+            "name": "Input 6",
+            "commands": [
+                "display.source.6"
+            ]
+        },
+        {
+            "id": "scene_09",
+            "name": "Input 7",
+            "commands": [
+                "display.source.7"
+            ]
+        },
+        {
+            "id": "scene_10",
+            "name": "Input 8",
+            "commands": [
+                "display.source.8"
+            ]
+        },
+        {
+            "id": "scene_11",
+            "name": "Input 9",
+            "commands": [
+                "display.source.9"
+            ]
+        },
+        {
+            "id": "scene_12",
+            "name": "Input 10",
+            "commands": [
+                "display.source.10"
+            ]
+        },
+        {
+            "id": "scene_13",
+            "name": "Input 11",
+            "commands": [
+                "display.source.11"
+            ]
+        },
+        {
+            "id": "scene_14",
+            "name": "Input 12",
+            "commands": [
+                "display.source.12"
+            ]
+        },
+        {
+            "id": "scene_15",
+            "name": "Input 13",
+            "commands": [
+                "display.source.13"
+            ]
+        },
+        {
+            "id": "scene_16",
+            "name": "Input 14",
+            "commands": [
+                "display.source.14"
+            ]
+        },
+        {
+            "id": "scene_17",
+            "name": "Input 15",
+            "commands": [
+                "display.source.15"
+            ]
+        },
+        {
+            "id": "scene_18",
+            "name": "Input 16",
+            "commands": [
+                "display.source.16"
+            ]
+        },
+        {
+            "id": "scene_19",
+            "name": "Input 17",
+            "commands": [
+                "display.source.17"
+            ]
+        },
+        {
+            "id": "scene_20",
+            "name": "Input 18",
+            "commands": [
+                "display.source.18"
+            ]
+        },
+        {
+            "id": "scene_21",
+            "name": "Input 19",
+            "commands": [
+                "display.source.19"
+            ]
+        }
+    ],
+    "styles": [
+        "display.main_method=power",
+        "display.icon=icon_tv",
+        "display.source.invisible=true"
+    ]
+}

--- a/test profiles/52 scene commands.json
+++ b/test profiles/52 scene commands.json
@@ -1,0 +1,430 @@
+{
+  "adapters": [
+    {
+      "model": "GenericNetworkAdapter",
+      "ip": "tcp://192.168.49.16:5000",
+      "ports": [
+        {
+          "id": "display",
+          "name": "Display",
+          "methods": [
+            {
+              "id": "power",
+              "name": "Power",
+              "command": "POWR%   \\x0D",
+              "params": [
+                {
+                  "id": "on",
+                  "name": "On",
+                  "value": "1"
+                },
+                {
+                  "id": "off",
+                  "name": "Off",
+                  "value": "0"
+                }
+              ],
+              "type": "actions"
+            },
+            {
+              "id": "source",
+              "name": "Source",
+              "command": "IAVD%   \\x0D",
+              "params": [
+                {
+                  "id": "hdmi1",
+                  "name": "HDMI 1",
+                  "value": "1"
+                },
+                {
+                  "id": "hdmi2",
+                  "name": "HDMI 2",
+                  "value": "2"
+                },
+                {
+                  "id": "hdmi3",
+                  "name": "HDMI 3",
+                  "value": "3"
+                },
+                {
+                  "id": "hdmi4",
+                  "name": "HDMI 4",
+                  "value": "4"
+                },
+                {
+                  "id": "vga",
+                  "name": "VGA",
+                  "value": "5"
+                },
+                {
+                  "id": "dp",
+                  "name": "DisplayPort",
+                  "value": "6"
+                },
+                {
+                  "id": "dvi",
+                  "name": "DVI",
+                  "value": "7"
+                },
+                {
+                  "id": "component",
+                  "name": "Component",
+                  "value": "8"
+                },
+                {
+                  "id": "composite",
+                  "name": "Composite",
+                  "value": "9"
+                },
+                {
+                  "id": "usb",
+                  "name": "USB",
+                  "value": "10"
+                }
+              ],
+              "type": "actions"
+            },
+            {
+              "id": "volume",
+              "name": "Volume",
+              "command": "VOLM%   \\x0D",
+              "params": [
+                {
+                  "id": "up",
+                  "name": "Up",
+                  "value": "+"
+                },
+                {
+                  "id": "down",
+                  "name": "Down",
+                  "value": "-"
+                },
+                {
+                  "id": "mute",
+                  "name": "Mute",
+                  "value": "M1"
+                },
+                {
+                  "id": "unmute",
+                  "name": "Unmute",
+                  "value": "M0"
+                }
+              ],
+              "type": "actions"
+            },
+            {
+              "id": "picture",
+              "name": "Picture Mode",
+              "command": "PICM%   \\x0D",
+              "params": [
+                {
+                  "id": "standard",
+                  "name": "Standard",
+                  "value": "1"
+                },
+                {
+                  "id": "vivid",
+                  "name": "Vivid",
+                  "value": "2"
+                },
+                {
+                  "id": "cinema",
+                  "name": "Cinema",
+                  "value": "3"
+                },
+                {
+                  "id": "sports",
+                  "name": "Sports",
+                  "value": "4"
+                },
+                {
+                  "id": "game",
+                  "name": "Game",
+                  "value": "5"
+                },
+                {
+                  "id": "dynamic",
+                  "name": "Dynamic",
+                  "value": "6"
+                },
+                {
+                  "id": "natural",
+                  "name": "Natural",
+                  "value": "7"
+                }
+              ],
+              "type": "actions"
+            },
+            {
+              "id": "aspect",
+              "name": "Aspect Ratio",
+              "command": "WIDE%   \\x0D",
+              "params": [
+                {
+                  "id": "auto",
+                  "name": "Auto",
+                  "value": "0"
+                },
+                {
+                  "id": "wide",
+                  "name": "Wide",
+                  "value": "1"
+                },
+                {
+                  "id": "zoom",
+                  "name": "Zoom",
+                  "value": "2"
+                },
+                {
+                  "id": "normal",
+                  "name": "Normal",
+                  "value": "3"
+                },
+                {
+                  "id": "stretch",
+                  "name": "Stretch",
+                  "value": "4"
+                },
+                {
+                  "id": "native",
+                  "name": "Native",
+                  "value": "5"
+                }
+              ],
+              "type": "actions"
+            },
+            {
+              "id": "menu",
+              "name": "Menu",
+              "command": "MENU%   \\x0D",
+              "params": [
+                {
+                  "id": "open",
+                  "name": "Open",
+                  "value": "1"
+                },
+                {
+                  "id": "close",
+                  "name": "Close",
+                  "value": "0"
+                },
+                {
+                  "id": "up",
+                  "name": "Up",
+                  "value": "U"
+                },
+                {
+                  "id": "down",
+                  "name": "Down",
+                  "value": "D"
+                },
+                {
+                  "id": "left",
+                  "name": "Left",
+                  "value": "L"
+                },
+                {
+                  "id": "right",
+                  "name": "Right",
+                  "value": "R"
+                },
+                {
+                  "id": "ok",
+                  "name": "OK",
+                  "value": "K"
+                },
+                {
+                  "id": "back",
+                  "name": "Back",
+                  "value": "B"
+                }
+              ],
+              "type": "actions"
+            },
+            {
+              "id": "numpad",
+              "name": "Numpad",
+              "command": "DKEY%   \\x0D",
+              "params": [
+                {
+                  "id": "n0",
+                  "name": "0",
+                  "value": "0"
+                },
+                {
+                  "id": "n1",
+                  "name": "1",
+                  "value": "1"
+                },
+                {
+                  "id": "n2",
+                  "name": "2",
+                  "value": "2"
+                },
+                {
+                  "id": "n3",
+                  "name": "3",
+                  "value": "3"
+                },
+                {
+                  "id": "n4",
+                  "name": "4",
+                  "value": "4"
+                },
+                {
+                  "id": "n5",
+                  "name": "5",
+                  "value": "5"
+                },
+                {
+                  "id": "n6",
+                  "name": "6",
+                  "value": "6"
+                },
+                {
+                  "id": "n7",
+                  "name": "7",
+                  "value": "7"
+                },
+                {
+                  "id": "n8",
+                  "name": "8",
+                  "value": "8"
+                },
+                {
+                  "id": "n9",
+                  "name": "9",
+                  "value": "9"
+                }
+              ],
+              "type": "actions"
+            },
+            {
+              "id": "channel",
+              "name": "Channel",
+              "command": "CHAN%   \\x0D",
+              "params": [
+                {
+                  "id": "up",
+                  "name": "Up",
+                  "value": "+"
+                },
+                {
+                  "id": "down",
+                  "name": "Down",
+                  "value": "-"
+                }
+              ],
+              "type": "actions"
+            },
+            {
+              "id": "info",
+              "name": "Info",
+              "command": "INFO%   \\x0D",
+              "params": [
+                {
+                  "id": "show",
+                  "name": "Show",
+                  "value": "1"
+                }
+              ],
+              "type": "actions"
+            },
+            {
+              "id": "sleep",
+              "name": "Sleep Timer",
+              "command": "OFTM%   \\x0D",
+              "params": [
+                {
+                  "id": "min30",
+                  "name": "30 min",
+                  "value": "30"
+                },
+                {
+                  "id": "min60",
+                  "name": "60 min",
+                  "value": "60"
+                }
+              ],
+              "type": "actions"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scenes": [
+    {
+      "id": "fire_all",
+      "name": "Fire All Commands",
+      "icon": "icon_alert",
+      "commands": [
+        "display.power.on",
+        "display.power.off",
+        "display.source.hdmi1",
+        "display.source.hdmi2",
+        "display.source.hdmi3",
+        "display.source.hdmi4",
+        "display.source.vga",
+        "display.source.dp",
+        "display.source.dvi",
+        "display.source.component",
+        "display.source.composite",
+        "display.source.usb",
+        "display.volume.up",
+        "display.volume.down",
+        "display.volume.mute",
+        "display.volume.unmute",
+        "display.picture.standard",
+        "display.picture.vivid",
+        "display.picture.cinema",
+        "display.picture.sports",
+        "display.picture.game",
+        "display.picture.dynamic",
+        "display.picture.natural",
+        "display.aspect.auto",
+        "display.aspect.wide",
+        "display.aspect.zoom",
+        "display.aspect.normal",
+        "display.aspect.stretch",
+        "display.aspect.native",
+        "display.menu.open",
+        "display.menu.close",
+        "display.menu.up",
+        "display.menu.down",
+        "display.menu.left",
+        "display.menu.right",
+        "display.menu.ok",
+        "display.menu.back",
+        "display.numpad.n0",
+        "display.numpad.n1",
+        "display.numpad.n2",
+        "display.numpad.n3",
+        "display.numpad.n4",
+        "display.numpad.n5",
+        "display.numpad.n6",
+        "display.numpad.n7",
+        "display.numpad.n8",
+        "display.numpad.n9",
+        "display.channel.up",
+        "display.channel.down",
+        "display.info.show",
+        "display.sleep.min30",
+        "display.sleep.min60"
+      ]
+    }
+  ],
+  "styles": [
+    "display.main_method=power",
+    "display.icon=icon_tv",
+    "display.source.invisible=true",
+    "display.volume.invisible=true",
+    "display.picture.invisible=true",
+    "display.aspect.invisible=true",
+    "display.menu.invisible=true",
+    "display.numpad.invisible=true",
+    "display.channel.invisible=true",
+    "display.info.invisible=true",
+    "display.sleep.invisible=true"
+  ]
+}

--- a/test profiles/mdi styles.json
+++ b/test profiles/mdi styles.json
@@ -1,0 +1,91 @@
+{
+    "adapters": [
+        {
+            "model": "GenericNetworkAdapter",
+            "ip": "tcp://192.168.49.16:5000",
+            "ports": [
+                {
+                    "id": "test",
+                    "name": "Test",
+                    "methods": [
+                        {
+                            "id": "ping",
+                            "name": "Ping",
+                            "command": "ping\\x0D",
+                            "params": [
+                                {
+                                    "id": "now",
+                                    "name": "Now",
+                                    "value": "now"
+                                }
+                            ],
+                            "type": "actions"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "scenes": [
+        {
+            "id": "v_filled",
+            "name": "filled",
+            "icon": "mdi:phone:filled",
+            "commands": [
+                "test.ping.now"
+            ]
+        },
+        {
+            "id": "v_outlined",
+            "name": "outlined",
+            "icon": "mdi:phone:outlined",
+            "commands": [
+                "test.ping.now"
+            ]
+        },
+        {
+            "id": "v_rounded",
+            "name": "rounded",
+            "icon": "mdi:phone:rounded",
+            "commands": [
+                "test.ping.now"
+            ]
+        },
+        {
+            "id": "v_sharp",
+            "name": "sharp",
+            "icon": "mdi:phone:sharp",
+            "commands": [
+                "test.ping.now"
+            ]
+        },
+        {
+            "id": "v_two_tone",
+            "name": "two_tone",
+            "icon": "mdi:phone:two_tone",
+            "commands": [
+                "test.ping.now"
+            ]
+        },
+        {
+            "id": "v_no_variant",
+            "name": "no variant",
+            "icon": "mdi:phone",
+            "commands": [
+                "test.ping.now"
+            ]
+        },
+        {
+            "id": "v_dangling",
+            "name": "dangling :",
+            "icon": "mdi:phone:",
+            "commands": [
+                "test.ping.now"
+            ]
+        }
+    ],
+    "styles": [
+        "test.main_method=ping",
+        "test.icon=mdi:phone:two_tone"
+    ]
+}


### PR DESCRIPTION
1. Added support for scenes ("the Scenes function allows Room Controls devotees to finally add Macros (multiple stacked commands on a single button)"). Note that the docs say the limit is 20 scenes, within those a maximum of 50 independent commands are supported; testing shows that the 20 scene limit is enforced but more than 50 commands are allowed - the code has been set to match this behavior but the 50-command limit is present in the code and commented out.
2. Updated output preview to show the event that caused the output and to show each individual destination and sent data
3. Zoom requires "action" to have no "params" but allows "actions" to have no "params." Updated behavior to match actual Zoom Rooms.